### PR TITLE
Fix issue automatic JIT includes on macOS

### DIFF
--- a/.github/workflows/ci_test.yaml
+++ b/.github/workflows/ci_test.yaml
@@ -44,12 +44,12 @@ jobs:
               if: ${{matrix.os == 'macos-latest'}}
               shell: bash
               working-directory: ${{runner.workspace}}/graph_framework/build
-              run: cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DUSE_METAL=ON ${{runner.workspace}}/graph_framework
+              run: cmake -DUSE_METAL=ON -DBUILD_C_BINDING=ON ${{runner.workspace}}/graph_framework
             - name: Configure CMake Linux
               if: ${{matrix.os == 'ubuntu-latest'}}
               shell: bash
               working-directory: ${{runner.workspace}}/graph_framework/build
-              run: cmake ${{runner.workspace}}/graph_framework
+              run: cmake -DBUILD_C_BINDING=ON -DBUILD_Fortran_BINDING=ON ${{runner.workspace}}/graph_framework
             - name: Build Mac
               if: ${{matrix.os == 'macos-latest'}}
               shell: bash

--- a/README.md
+++ b/README.md
@@ -40,6 +40,3 @@ For instructions to build the code consult the
 documentation. This framework uses a [cmake](https://cmake.org) based build 
 system and requires the 
 [NetCDF-C](https://www.unidata.ucar.edu/software/netcdf/) library.
-
-NOTE: macOS users will need to change the `CMAKE_CXX_COMPILER` to `clang++`. 
-Otherwise the framework will not set the includes correctly for CPU JIT.

--- a/graph_docs/compiling.dox
+++ b/graph_docs/compiling.dox
@@ -89,15 +89,6 @@
  * <tr><td><tt>USE_SSH</tt>              <td>Use ssh for git instead of html.
  * </table>
  *
- * @note macOS users will need to change the default option for
- * <tt>CMAKE_CXX_COMPILER</tt> to <tt>clang++</tt>. This is due to the way the
- * build systems determines default include directories for system libraries.
- * This can be accomplished using the advanced options accessed from the <tt>t</tt>
- * command or setting this via the command line.
- * @code
- cmake -DCMAKE_CXX_COMPILER=clang++ ../
- @endcode
- *
  * Any time an option is changed, or a new option becomes is available, you need
  * to use the configure <tt>c</tt> command for changes to take affect. Once all
  * options are set, a generate <tt>g</tt> options will appear. Using this option

--- a/graph_framework/trigonometry.hpp
+++ b/graph_framework/trigonometry.hpp
@@ -115,7 +115,7 @@ namespace graph {
             if (this->is_match(x)) {
                 return one<T, SAFE_MATH> ();
             }
-            
+
             const size_t hash = reinterpret_cast<size_t> (x.get());
             if (this->df_cache.find(hash) == this->df_cache.end()) {
                 this->df_cache[hash] = cos(this->arg)*this->arg->df(x);
@@ -313,7 +313,13 @@ namespace graph {
 ///  @returns Reduced graph from cosine.
 //------------------------------------------------------------------------------
         virtual shared_leaf<T, SAFE_MATH> reduce() {
-            if (constant_cast(this->arg).get()) {
+            auto c = constant_cast(this->arg);
+            if (c.get()) {
+//  GNU complex revalues cos(0, i0) evaluates to (1, -i0). This is casuing a
+//  problem with the c and fortran binding tests.
+                if (c->is(0)) {
+                    return one<T, SAFE_MATH> ();
+                }
                 return constant<T, SAFE_MATH> (this->evaluate());
             }
 

--- a/utilities/get_includes.py
+++ b/utilities/get_includes.py
@@ -4,6 +4,8 @@
 #-------------------------------------------------------------------------------
 import argparse
 import subprocess
+import shutil
+import os
 
 #-------------------------------------------------------------------------------
 ##  @brief Parse the output to get the include directories.
@@ -11,9 +13,17 @@ import subprocess
 ##  @param[in] args Command line arguments.
 #-------------------------------------------------------------------------------
 def main(**args):
-    output = subprocess.run([args['compiler'], '-Wp,-v', '-x', 'c++', '/dev/null', '-fsyntax-only'],
-                            capture_output=True,
-                            text=True).stderr
+    full_path = args['compiler'];
+    command = os.path.basename(full_path)
+
+    if shutil.which(command) is not None:
+        output = subprocess.run([command, '-Wp,-v', '-x', 'c++', '/dev/null', '-fsyntax-only'],
+                                capture_output=True,
+                                text=True).stderr
+    else:
+        output = subprocess.run([full_path, '-Wp,-v', '-x', 'c++', '/dev/null', '-fsyntax-only'],
+                                capture_output=True,
+                                text=True).stderr
 
     start_capture = False
     includes = ''


### PR DESCRIPTION
The include files that came from `get_includes.py` is different when using the full path vs. command directly. Refactor to remove the command path. This fixes

https://github.com/ORNL-Fusion/graph_framework/issues/1

